### PR TITLE
Fix YouTube import by replacing eval with JSON.parse

### DIFF
--- a/youtube-musicbrainz-import.user.js
+++ b/youtube-musicbrainz-import.user.js
@@ -39,7 +39,7 @@ var icon;
 function yt_callback(req) {
     if (req.readyState != 4)
         return;
-    var r = eval('(' + req.responseText + ')').items[0];
+    var r = JSON.parse(req.responseText).items[0];
 
     var video_id = r.id;
     var title = r.snippet.title;
@@ -79,7 +79,7 @@ function mb_callback(req) {
     if (req.readyState != 4){
         return;
     }
-    var r = eval('(' + req.responseText + ')');
+    var r = JSON.parse(req.responseText);
 
     if (r.relations !== undefined && r.relations.length > 0) {
         div.innerHTML = "<div class='holder'><a style='text-decoration: none' href='//musicbrainz.org/url/" + r.id + "'><button style='background-color:#a4a4a4;' class='search-button'>Added ✓</button></a></div>";


### PR DESCRIPTION
The YouTube import script is currently broken because calls to `eval()` are forbidden by YouTube's CSP settings. This is because `eval()` can execute arbitrary code, which is unnecessary with this call because we are just parsing the JSON response.

So, this switches to the safer and effective `JSON.parse`, which fixes #17.